### PR TITLE
Lower arbitrary perl requirement of Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.010001;
+use 5.008001;
  
 use strict;
 use warnings;
@@ -20,6 +20,7 @@ WriteMakefile(
         },
     },
 
+    MIN_PERL_VERSION => '5.008001',
     PREREQ_PM => {
         'Carp' => 0,
         'List::Util' => 0,


### PR DESCRIPTION
I've confirmed that this distribution works on perl 5.8.1, as the module itself requires. This lowers the Makefile.PL requirement to match and also sets MIN_PERL_VERSION for ExtUtils::MakeMaker.