### PR TITLE
Runtime Test::More prereq for Protocol::Redis::Test

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,7 @@ WriteMakefile(
     PREREQ_PM => {
         'Carp' => 0,
         'List::Util' => 0,
+        'Test::More' => '0.94',
     },
     TEST_REQUIRES => {
         'Test::More' => '0.88'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,6 @@ WriteMakefile(
     MIN_PERL_VERSION => '5.008001',
     PREREQ_PM => {
         'Carp' => 0,
-        'List::Util' => 0,
         'Test::More' => '0.94',
     },
     TEST_REQUIRES => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ WriteMakefile(
         'Test::More' => '0.94',
     },
     TEST_REQUIRES => {
-        'Test::More' => '0.88'
+        'Test::More' => '0.94'
     },
     test => {TESTS =>  't/*.t'},
 


### PR DESCRIPTION
Protocol::Redis::Test requires Test::More 0.94 for [subtest support](https://metacpan.org/pod/Test::More#COMPATIBILITY) - also, this needs to be a runtime prereq, so it's installed for Protocol::Redis::Test's runtime (even though that is usually during another module's test phase). Also, removed prereq on List::Util as it is not actually used anywhere.