### PR TITLE
Quote version

### DIFF
--- a/lib/Protocol/Redis.pm
+++ b/lib/Protocol/Redis.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use 5.008_001;
 
-our $VERSION = 1.0006;
+our $VERSION = '1.0006';
 
 require Carp;
 


### PR DESCRIPTION
Even using decimal versions which act like numbers, versions are still strings and should be declared as such so we don't lose trailing zeroes or get subject to floating point issues.