### PR TITLE
Avoid context sensitive return in constructor from invalid api value

### DIFF
--- a/lib/Protocol/Redis.pm
+++ b/lib/Protocol/Redis.pm
@@ -14,7 +14,7 @@ sub new {
 
     my $self = {@_};
 
-    return unless $self->{api} == '1';
+    return undef unless $self->{api} == '1';
 
     bless $self, $class;
 


### PR DESCRIPTION
This fixes the following context sensitivity issue:

```
my %data = (redis => Protocol::Redis->new(api => 42), foo => 'bar');
# {redis => 'foo', bar => undef}
```

I personally would prefer it just throw an exception, but that would be a breaking change