### PR TITLE
test and fix encoding 0 as a double in RESP3

### DIFF
--- a/lib/Protocol/Redis.pm
+++ b/lib/Protocol/Redis.pm
@@ -221,7 +221,7 @@ sub _encode_resp3 {
         # Double
         elsif ($message->{type} eq ',') {
             # inf
-            if ($message->{data} == $message->{data} * 2) {
+            if ($message->{data} != 0 and $message->{data} == $message->{data} * 2) {
                 $encoded_message .= ',' . ($message->{data} > 0 ? '' : '-') . "inf\r\n";
             }
             # nan

--- a/lib/Protocol/Redis/Test.pm
+++ b/lib/Protocol/Redis/Test.pm
@@ -47,7 +47,7 @@ sub _apiv3_ok {
     my $redis_class = shift;
 
     subtest 'Protocol::Redis APIv3 ok' => sub {
-        plan tests => 150;
+        plan tests => 151;
 
         _test_version_3($redis_class);
     }
@@ -841,6 +841,8 @@ sub _encode_v3_ok {
       'encode negative double with exponent';
     is $redis->encode({type => ',', data => '10'}), ",10\r\n",
       'encode integer as double';
+    is $redis->encode({type => ',', data => '0'}), ",0\r\n",
+      'encode zero as double';
     is $redis->encode({type => ',', data => 9**9**9}), ",inf\r\n",
       'encode inf';
     is $redis->encode({type => ',', data => -9**9**9}), ",-inf\r\n",


### PR DESCRIPTION
Left a logic error in that would result in 0 being encoded as `,-inf` rather than `,0`. Add a test to make sure.